### PR TITLE
Adding tools and finder for Highloadblock module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ $groupCode = GroupTools::findById(3)->code();
 // And that's not all ;-)
 ```
 
+* HlBlockTools: finder for highloadblock IDs by it's names.
+
+```php
+<?php
+use Bex\Tools\HlBlockTools;
+
+$hlBlockFinder = HlBlockTools::find('ReferenceName');
+
+$hlBlockId = $hlBlockFinder->id();
+$hlBlockName = HlBlockTools::findById(2)->name();
+
+```
+
 * Prevents the creation of infoblocks with the same codes.
 * Prevents the creation of user groups with the same string id.
 

--- a/src/HlBlock/HlBlockFinder.php
+++ b/src/HlBlock/HlBlockFinder.php
@@ -182,7 +182,7 @@ class HlBlockFinder extends Finder
             throw new ValueNotFoundException('HlBlock', 'ID #' . $this->id);
         }
 
-        $this->registerCacheTag(self::$cacheTag);
+        $this->registerCacheTag(static::$cacheTag);
 
         return $items;
     }
@@ -193,6 +193,6 @@ class HlBlockFinder extends Finder
      */
     public static function onAfterSomething(Event $event)
     {
-        static::deleteCacheByTag(self::$cacheTag);
+        static::deleteCacheByTag(static::$cacheTag);
     }
 }

--- a/src/HlBlock/HlBlockFinder.php
+++ b/src/HlBlock/HlBlockFinder.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * @link https://github.com/bitrix-expert/tools
+ * @copyright Copyright © 2015 Nik Samokhvalov
+ * @license MIT
+ */
+
+namespace Bex\Tools\HlBlock;
+
+use Bex\Tools\Finder;
+use Bex\Tools\ValueNotFoundException;
+use Bitrix\Highloadblock\HighloadBlockTable;
+use Bitrix\Main\ArgumentNullException;
+use Bitrix\Main\Entity\Event;
+use Bitrix\Main\Loader;
+use Bitrix\Main\LoaderException;
+
+/**
+ * Finder of the highloadblocks.
+ *
+ * @author Mikhail Zhurov <mmjurov@gmail.com>
+ */
+class HlBlockFinder extends Finder
+{
+
+    protected static $cacheDir = 'bex_tools/hlblocks';
+    protected static $cacheTag = 'bex_tools_hlblocks';
+    protected $id;
+    protected $name;
+
+    /**
+     * @inheritdoc
+     *
+     * @throws ArgumentNullException Empty parameters in the filter
+     * @throws LoaderException Module "iblock" not installed
+     */
+    public function __construct(array $filter, $silenceMode = false)
+    {
+        if (!Loader::includeModule('highloadblock'))
+        {
+            throw new LoaderException('Failed include module "highloadblock"');
+        }
+        
+        parent::__construct($filter, $silenceMode);
+
+        $filter = $this->prepareFilter($filter);
+
+        if (isset($filter['name']))
+        {
+            $this->name = $filter['name'];
+        }
+
+        if (isset($filter['id']))
+        {
+            $this->id = $filter['id'];
+        }
+        else
+        {
+            $this->id = $this->getFromCache(
+                ['type' => 'id']
+            );
+        }
+    }
+
+    /**
+     * Gets hlblock ID.
+     *
+     * @return integer
+     */
+    public function id()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Gets hlblock name.
+     *
+     * @return string
+     */
+    public function name()
+    {
+        return $this->getFromCache(
+            ['type' => 'name'],
+            $this->id
+        );
+    }
+
+    /**
+     * @inheritdoc
+     * 
+     * @throws ArgumentNullException Empty parameters in the filter
+     */
+    protected function prepareFilter(array $filter)
+    {
+        foreach ($filter as $code => &$value)
+        {
+            if ($code === 'id')
+            {
+                intval($value);
+
+                if ($value <= 0)
+                {
+                    throw new ArgumentNullException($code);
+                }
+            }
+            else
+            {
+                trim(htmlspecialchars($value));
+
+                if (strlen($value) <= 0)
+                {
+                    throw new ArgumentNullException($code);
+                }
+            }
+        }
+
+        return $filter;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws ArgumentNullException
+     * @throws ValueNotFoundException
+     */
+    protected function getValue(array $cache, array $filter, $shard)
+    {
+        switch ($filter['type'])
+        {
+            case 'id':
+                if (isset($this->id))
+                {
+                    return $this->id;
+                }
+
+                $value = (int)$cache[$this->name];
+
+                if ($value <= 0)
+                {
+                    throw new ValueNotFoundException('HlBlock ID', 'hlblock name "' . $this->name . '"');
+                }
+
+                return $value;
+                break;
+
+            case 'name':
+                $value = (string)$this->name;
+
+                if (strlen($value) <= 0)
+                {
+                    throw new ValueNotFoundException('HlBlock name', 'hlblock #' . $this->id);
+                }
+
+                return $value;
+                break;
+
+            default:
+                throw new \InvalidArgumentException('Invalid type on filter');
+                break;
+        }
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    protected function getItems($shard)
+    {
+        $items = [];
+
+        $dbHlBlocks = HighloadBlockTable::query()
+            ->setSelect(['NAME', 'ID'])
+            ->exec();
+
+        while ($hlBlock = $dbHlBlocks->fetch())
+        {
+            $items[ $hlBlock['NAME'] ] = $hlBlock['ID'];
+        }
+
+        if (empty($items))
+        {
+            throw new ValueNotFoundException('HlBlock', 'ID #' . $this->id);
+        }
+
+        $this->registerCacheTag(self::$cacheTag);
+
+        return $items;
+    }
+
+    /**
+     * Event handler for clearing cache dependencies
+     * @param Event $event
+     */
+    public static function onAfterSomething(Event $event)
+    {
+        static::deleteCacheByTag(self::$cacheTag);
+    }
+}

--- a/src/HlBlock/HlBlockTools.php
+++ b/src/HlBlock/HlBlockTools.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @link https://github.com/bitrix-expert/tools
+ * @copyright Copyright © 2015 Nik Samokhvalov
+ * @license MIT
+ */
+
+namespace Bex\Tools\HlBlock;
+
+/**
+ * Tools for working with users groups.
+ *
+ * @author Mikhail Zhurov <mmjurov@gmail.com>
+ */
+class HlBlockTools
+{
+    /**
+     * Gets Finder for hlblock by it's name
+     *
+     * @param string $name HlBlock name
+     * @param bool $silenceMode When you use silence mode instead of an exception \Bex\Tools\ValueNotFoundException 
+     * (if value was be not found) is returned null.
+     *
+     * @return HlBlockFinder
+     */
+    public static function find($name, $silenceMode = false)
+    {
+        return new HlBlockFinder(
+            ['name' => $name],
+            $silenceMode
+        );
+    }
+
+    /**
+     * Gets Finder for HlBlock by it's ID.
+     *
+     * @param int $id HlBlock ID
+     * @param bool $silenceMode When you use silence mode instead of an exception \Bex\Tools\ValueNotFoundException 
+     * (if value was be not found) is returned null.
+     *
+     * @return HlBlockFinder
+     */
+    public static function findById($id, $silenceMode = false)
+    {
+        return new HlBlockFinder(
+            ['id' => $id],
+            $silenceMode
+        );
+    }
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -22,3 +22,13 @@ $manager->addEventHandler('iblock', 'OnBeforeIBlockUpdate', ['\Bex\Tools\Iblock\
 $manager->addEventHandler('iblock', 'OnAfterIBlockAdd', ['\Bex\Tools\Iblock\IblockFinder', 'onAfterIBlockAdd']);
 $manager->addEventHandler('iblock', 'OnAfterIBlockUpdate', ['\Bex\Tools\Iblock\IblockFinder', 'onAfterIBlockUpdate']);
 $manager->addEventHandler('iblock', 'OnIBlockDelete', ['\Bex\Tools\Iblock\IblockFinder', 'onIBlockDelete']);
+
+$manager->addEventHandler('highloadblock', '\Bitrix\Highloadblock\HighloadBlock::OnAdd',
+    ['\Bex\Tools\HlBlock\HlBlockFinder', 'onAfterSomething']
+);
+$manager->addEventHandler('highloadblock', '\Bitrix\Highloadblock\HighloadBlock::OnAfterUpdate',
+    ['\Bex\Tools\HlBlock\HlBlockFinder', 'onAfterSomething']
+);
+$manager->addEventHandler('highloadblock', '\Bitrix\Highloadblock\HighloadBlock::OnAfterDelete',
+    ['\Bex\Tools\HlBlock\HlBlockFinder', 'onAfterSomething']
+);


### PR DESCRIPTION
Добавил для highload блоков. Иногда нужно обращаться к ID-шникам HL-блоков. В качестве основы для обращения выбрал имя HL-блока.
Реализовывать доступ к ID-шникам пользовательских свойств не стал, т.к. это должна быть отдельная группа классов, а в HL-блоки можно его потом включить, если будет необходимо.
