### PR TITLE
1.x cache warmup

### DIFF
--- a/src/Iblock/IblockFinder.php
+++ b/src/Iblock/IblockFinder.php
@@ -416,14 +416,16 @@ class IblockFinder extends Finder
      */
     protected static function delayCacheCollector($iblockId)
     {
+        if (empty(static::$delayedIblocks)) {
+            EventManager::getInstance()->addEventHandler(
+                'main', 'OnEpilog', [get_called_class(), 'onEpilog']
+            );
+        }
+
         static::$delayedIblocks[] = $iblockId;
 
         //Collecting only lite cache
         new static([]);
-        EventManager::getInstance()->addEventHandler(
-            'main', 'OnEpilog', [get_called_class(), 'onEpilog']
-        );
-
     }
 
     public static function onAfterIBlockAdd(&$fields)
@@ -455,8 +457,6 @@ class IblockFinder extends Finder
     {
         if ($fields['RESULT']) {
             static::deleteCacheByTag('bex_iblock_' . $fields['IBLOCK_ID']);
-            static::deleteCacheByTag('bex_iblock_new');
-
             static::runCacheCollectorById($fields['IBLOCK_ID']);
         }
     }
@@ -478,6 +478,7 @@ class IblockFinder extends Finder
     {
         $iblockIds = static::$delayedIblocks;
         if (!empty($iblockIds)) {
+
             foreach ($iblockIds as $iblockId) {
 
                 static::runCacheCollectorById($iblockId);

--- a/src/Iblock/IblockFinder.php
+++ b/src/Iblock/IblockFinder.php
@@ -172,7 +172,7 @@ class IblockFinder extends Finder
     protected static function runCacheCollectorById($iblockId = null)
     {
         if (!$iblockId) {
-            return self::runCacheCollector();
+            return static::runCacheCollector();
         }
 
         $finder = new static(['id' => $iblockId]);
@@ -421,7 +421,7 @@ class IblockFinder extends Finder
         //Collecting only lite cache
         new static([]);
         EventManager::getInstance()->addEventHandler(
-            'main', 'OnEpilog', [__CLASS__, 'onEpilog']
+            'main', 'OnEpilog', [get_called_class(), 'onEpilog']
         );
 
     }
@@ -457,13 +457,13 @@ class IblockFinder extends Finder
             static::deleteCacheByTag('bex_iblock_' . $fields['IBLOCK_ID']);
             static::deleteCacheByTag('bex_iblock_new');
 
-            self::runCacheCollectorById($fields['IBLOCK_ID']);
+            static::runCacheCollectorById($fields['IBLOCK_ID']);
         }
     }
 
     public static function onAfterIBlockPropertyUpdate(&$fields)
     {
-        self::onAfterIBlockPropertyAdd($fields);
+        static::onAfterIBlockPropertyAdd($fields);
     }
 
     /**
@@ -480,7 +480,7 @@ class IblockFinder extends Finder
         if (!empty($iblockIds)) {
             foreach ($iblockIds as $iblockId) {
 
-                self::runCacheCollectorById($iblockId);
+                static::runCacheCollectorById($iblockId);
             }
         }
     }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -32,6 +32,8 @@ class Loader
         ['iblock', 'OnBeforeIBlockUpdate', ['\Bex\Tools\Iblock\IblockTools', 'onBeforeIBlockUpdate']],
         ['iblock', 'OnAfterIBlockAdd', ['\Bex\Tools\Iblock\IblockFinder', 'onAfterIBlockAdd']],
         ['iblock', 'OnAfterIBlockUpdate', ['\Bex\Tools\Iblock\IblockFinder', 'onAfterIBlockUpdate']],
+        ['iblock', 'OnAfterIBlockPropertyAdd', ['\Bex\Tools\Iblock\IblockFinder', 'onAfterIBlockPropertyAdd']],
+        ['iblock', 'OnAfterIBlockPropertyUpdate', ['\Bex\Tools\Iblock\IblockFinder', 'onAfterIBlockPropertyUpdate']],
         ['iblock', 'OnIBlockDelete', ['\Bex\Tools\Iblock\IblockFinder', 'onIBlockDelete']],
         ['highloadblock', '\Bitrix\Highloadblock\HighloadBlock::OnAdd', ['\Bex\Tools\HlBlock\HlBlockFinder', 'onAfterSomething']],
         ['highloadblock', '\Bitrix\Highloadblock\HighloadBlock::OnAfterUpdate', ['\Bex\Tools\HlBlock\HlBlockFinder', 'onAfterSomething']],


### PR DESCRIPTION
Добавил динамический обработчик OnEpilog, который будет собирать кеш измененных инфоблоков в процессе выполнения хита. 
Добавил события добавления и обновления свойства для пересборки кеша инфоблока.
Добавил runCacheCollectorById, который делает то же самое, что и runCacheCollector. В принципе, можно вообще избавиться от runCacheCollector, т.к. он фактически не используется. Разве что только если он использовался извне, то потеряем обратную совместимость. 

Не хочу сказать, что уж прям сильно тестировал, но по несколько раз с отладчиком до каждого события добрался, с виду все должно работать как надо.
