### PR TITLE
#6 Collecting lite cache after add/update iblock

### DIFF
--- a/src/Iblock/IblockFinder.php
+++ b/src/Iblock/IblockFinder.php
@@ -429,6 +429,7 @@ class IblockFinder extends Finder
     {
         if ($fields['ID'] > 0) {
             static::deleteCacheByTag('bex_iblock_new');
+            new static(['type' => $fields['IBLOCK_TYPE_ID'], 'code' => $fields['CODE']]);
             static::delayCacheCollector($fields['ID']);
         }
     }
@@ -438,6 +439,7 @@ class IblockFinder extends Finder
         if ($fields['RESULT']) {
             static::deleteCacheByTag('bex_iblock_' . $fields['ID']);
             static::deleteCacheByTag('bex_iblock_new');
+            new static(['type' => $fields['IBLOCK_TYPE_ID'], 'code' => $fields['CODE']]);
             static::delayCacheCollector($fields['ID']);
         }
     }


### PR DESCRIPTION
В продолжение #10 ПР.
На самом деле, правильнее было бы внести правки в конструктор IblockFinder, т.к. при отсутствии фильтра по id он сразу пытается получить хоть какое-нибудь значение методом getFromCache(). При этом конструктор не обязывает заполнять code и type фильтры, тогда как метод getValueLiteShard() без них работать не будет.

getFromCache я бы разделил на двое - собственно запись и получение списка инфоблоков из кеша и получение нужного значения по фильтру.
