### PR TITLE
Исправление ошибки отсутствия code и type при обработке события onAfterIBlockUpdate

### DIFF
--- a/src/Iblock/IblockFinder.php
+++ b/src/Iblock/IblockFinder.php
@@ -439,7 +439,7 @@ class IblockFinder extends Finder
         if ($fields['RESULT']) {
             static::deleteCacheByTag('bex_iblock_' . $fields['ID']);
             static::deleteCacheByTag('bex_iblock_new');
-            new static(['type' => $fields['IBLOCK_TYPE_ID'], 'code' => $fields['CODE']]);
+            new static(['id' => $fields['ID']]);
             static::delayCacheCollector($fields['ID']);
         }
     }


### PR DESCRIPTION
Исправлена проблема, при которой обработчик события \Bex\Tools\Iblock\IblockFinder::onAfterIBlockUpdate ломался из-за отсутствия полей `$fields['IBLOCK_TYPE_ID']` и `$fields['CODE']`, а именно создание объекта `new static(...)`