### PR TITLE
Исправление ошибки отсутствия записи в кеше при создании объекта в хендлере \Bex\Tools\Iblock\IblockFinder::onAfterIBlockAdd

### DIFF
--- a/src/Iblock/IblockFinder.php
+++ b/src/Iblock/IblockFinder.php
@@ -429,7 +429,7 @@ class IblockFinder extends Finder
     {
         if ($fields['ID'] > 0) {
             static::deleteCacheByTag('bex_iblock_new');
-            new static(['type' => $fields['IBLOCK_TYPE_ID'], 'code' => $fields['CODE']]);
+            new static(['id' => $fields['ID']]);
             static::delayCacheCollector($fields['ID']);
         }
     }


### PR DESCRIPTION
После создания инфоблока происходит пересоздание объекта с указанием фильтра по type и code: http://joxi.ru/V2VYMXwhxB6Jzm.

Далее в конструкторе происходит обращение к кешу, чтобы найти ID нового инфоблока: http://joxi.ru/xAe53j4FpMQxyA

В кеше данного инфоблока не оказывается, и мы получаем ошибку: http://joxi.ru/Y2LkxWwf9x0JZm

Данный PR устраняет эту ошибку, передавая в конструктор ID только что созданного инфоблока, что исключает ненужные повторные запросы.